### PR TITLE
Add shutdown notification

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -1,12 +1,31 @@
-import asyncio, os
+import asyncio, os, signal
 from bot import notifier
+from bot import test_connection
 
 INTERVAL = int(os.getenv("CHECK_INTERVAL", 300))
 
+stop_event = asyncio.Event()
+
+
+async def shutdown() -> None:
+    """Send a disconnect notice and stop the loop."""
+    await notifier.bot.send_message(
+        chat_id=notifier.user_id, text="❌ Bot de notificaciones detenido"
+    )
+    stop_event.set()
+
 async def main():
-    while True:
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, lambda s=sig: asyncio.create_task(shutdown()))
+
+    await test_connection.run()
+    while not stop_event.is_set():
         await notifier.send_report()
-        await asyncio.sleep(INTERVAL)
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=INTERVAL)
+        except asyncio.TimeoutError:
+            pass
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/bot/notifier.py
+++ b/bot/notifier.py
@@ -16,8 +16,7 @@ async def send_report():
         try:
             output = mod.run()
             if output:
-                msgs.append(f"[{mod_name}]
-{output}")
+                msgs.append(f"[{mod_name}] {output}")
         except Exception as e:
             msgs.append(f"[{mod_name}] Error: {e}")
     await bot.send_message(chat_id=user_id, text="\n\n".join(msgs[:10]))

--- a/bot/test_connection.py
+++ b/bot/test_connection.py
@@ -1,0 +1,17 @@
+import os
+from telegram import Bot
+
+
+async def run() -> None:
+    """Send a test message to confirm bot connectivity."""
+    token = os.getenv("BOT_TOKEN")
+    user = os.getenv("TELEGRAM_USER_ID")
+    if not token or not user:
+        raise RuntimeError("BOT_TOKEN and TELEGRAM_USER_ID must be set")
+    bot = Bot(token=token)
+    await bot.send_message(chat_id=int(user), text="✅ Bot de notificaciones conectado")
+
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(run())

--- a/bot/test_full.py
+++ b/bot/test_full.py
@@ -1,0 +1,9 @@
+import asyncio
+from bot import notifier, test_connection
+
+async def run() -> None:
+    await test_connection.run()
+    await notifier.send_report()
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- send a notification when the container is stopping
- refactor main loop with signal handling
- add a full test script to send connection and full report

## Testing
- `python3 -m py_compile bot/main.py bot/notifier.py bot/test_connection.py bot/test_full.py bot/modules/*.py`
- `PYTHONPATH=. python3 bot/test_full.py`

------
https://chatgpt.com/codex/tasks/task_e_686999953b6083289abe22557e2e1143