### PR TITLE
Fix import path for bot package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,13 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Ensure the package is discoverable
+ENV PYTHONPATH=/app
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY bot/ ./bot
 
-CMD ["python", "-u", "bot/main.py"]
+# Execute bot as a module so Python can resolve package imports correctly
+CMD ["python", "-u", "-m", "bot.main"]


### PR DESCRIPTION
## Summary
- ensure the bot package is on `PYTHONPATH` in the container

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6869ac717af88328a88d232965597048